### PR TITLE
✨ Add validation to prevent use of blocked terms within SMS Sender IDs

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -52,6 +52,7 @@ from app.main.validators import (
     OnlySMSCharacters,
     ValidEmail,
     ValidGovEmail,
+    SenderBlocklistValidator,
 )
 from app.models.feedback import PROBLEM_TICKET_TYPE, QUESTION_TICKET_TYPE
 from app.models.organisation import Organisation
@@ -1673,10 +1674,10 @@ class ServiceSmsSenderForm(StripWhitespaceForm):
             Length(min=3, message="Enter 3 characters or more"),
             LettersNumbersFullStopsAndUnderscoresOnly(),
             DoesNotStartWithDoubleZero(),
+            SenderBlocklistValidator(values=[])
         ]
     )
     is_default = GovukCheckboxField("Make this text message sender the default")
-
 
 class ServiceEditInboundNumberForm(StripWhitespaceForm):
     is_default = GovukCheckboxField("Make this text message sender the default")

--- a/app/main/validators.py
+++ b/app/main/validators.py
@@ -15,6 +15,18 @@ from app.models.spreadsheet import Spreadsheet
 from app.utils import is_gov_user
 
 
+class SenderBlocklistValidator:
+    def __init__(self, values=[], message=None):
+        if not message:
+            message = 'This sender is not allowed'
+        self.message = message
+        self.values = values
+
+    def __call__(self, form, field):
+        validation_failed = any(word in field.data for word in self.values)
+        if validation_failed:
+            raise ValidationError(self.message)
+
 class CommonlyUsedPassword:
     def __init__(self, message=None):
         if not message:

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -67,6 +67,8 @@ from app.utils import (
     user_is_platform_admin,
 )
 
+from app.main.validators import SenderBlocklistValidator
+
 PLATFORM_ADMIN_SERVICE_PERMISSIONS = OrderedDict([
     ('inbound_sms', {'title': 'Receive inbound SMS', 'requires': 'sms', 'endpoint': '.service_set_inbound_number'}),
     ('email_auth', {'title': 'Email authentication'}),
@@ -863,6 +865,10 @@ def service_sms_senders(service_id):
 @user_has_permissions('manage_service')
 def service_add_sms_sender(service_id):
     form = ServiceSmsSenderForm()
+    blocklist_values = service_api_client.get_blocklist_for_service(service_id)['blocklist']
+    blocklist_validator = next(validator for validator in form.sms_sender.validators if type(validator) == SenderBlocklistValidator)
+    blocklist_validator.values = blocklist_values
+
     first_sms_sender = current_service.count_sms_senders == 0
     if form.validate_on_submit():
         service_api_client.add_sms_sender(

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -52,6 +52,9 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         """
         return self.get('/service', params=params_dict)
 
+    def get_blocklist_for_service(self, service_id):
+        return self.get('/service/{}/blocklist'.format(service_id))
+
     def find_services_by_name(self, service_name):
         return self.get('/service/find-services-by-name', params={"service_name": service_name})
 


### PR DESCRIPTION
To help avoid abuse of the CAST Notify service, as well as protect our
accounts with backend providers like firetext, we want to apply some
restrictions on the Sender IDs that users can apply to our outbound SMS
and emails.

This PR adds support to fetch a blocklist from a (newly added) API
endpoint, as well as introducing a new WTForms validator that'll raise
a validation error if/when a blocked phrase features within the SMS
sender that has been submitted by the user.

https://app.asana.com/0/1199707043388412/1199940470983800

<img width="579" alt="Screenshot 2021-02-17 at 13 37 45" src="https://user-images.githubusercontent.com/1914715/108212049-593f9580-7125-11eb-999a-2b6e92fd30ec.png">
