### PR TITLE
♻️ Update signup process

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -41,6 +41,8 @@ class Config(object):
         'emergency_service': 25000,
         'school_or_college': 25000,
         'other': 25000,
+        'charity': 25000,
+        'community_interest': 25000
     }
     EMAIL_EXPIRY_SECONDS = 3600  # 1 hour
     INVITATION_EXPIRY_SECONDS = 3600 * 24 * 2  # 2 days - also set on api

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -597,7 +597,6 @@ class RegisterUserForm(StripWhitespaceForm):
     # always register as sms type
     auth_type = HiddenField('auth_type', default='sms_auth')
 
-
 class RegisterUserFromInviteForm(RegisterUserForm):
     def __init__(self, invited_user):
         super().__init__(
@@ -1211,6 +1210,10 @@ class CreateServiceForm(StripWhitespaceForm):
             Length(max=255, message='Service name must be 255 characters or fewer')
         ])
     organisation_type = OrganisationTypeField('Who runs this service?')
+    service_description = GovukTextInputField(
+        'What type of work do you do?',
+        validators=[DataRequired(message='Cannot be empty')]
+    )
 
 
 class CreateNhsServiceForm(CreateServiceForm):

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -591,7 +591,7 @@ class RegisterUserForm(StripWhitespaceForm):
         'Full name',
         validators=[DataRequired(message='Cannot be empty')]
     )
-    email_address = email_address()
+    email_address = email_address(gov_user=False)
     mobile_number = international_phone_number()
     password = password()
     # always register as sms type

--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -6,7 +6,7 @@ from app import billing_api_client, service_api_client
 from app.formatters import email_safe
 from app.main import main
 from app.main.forms import CreateNhsServiceForm, CreateServiceForm
-from app.utils import user_is_gov_user, user_is_logged_in
+from app.utils import user_is_logged_in
 
 
 def _create_service(service_name, organisation_type, email_from, form):
@@ -46,7 +46,6 @@ def _create_example_template(service_id):
 
 @main.route("/add-service", methods=['GET', 'POST'])
 @user_is_logged_in
-@user_is_gov_user
 def add_service():
     default_organisation_type = current_user.default_organisation_type
     if default_organisation_type == 'nhs':

--- a/app/models/organisation.py
+++ b/app/models/organisation.py
@@ -19,14 +19,9 @@ class Organisation(JSONModel):
     TYPE_OTHER = 'other'
 
     TYPES = (
-        (TYPE_CENTRAL, 'Central government'),
-        (TYPE_LOCAL, 'Local government'),
-        (TYPE_NHS_CENTRAL, 'NHS – central government agency or public body'),
-        (TYPE_NHS_LOCAL, 'NHS Trust or Clinical Commissioning Group'),
-        (TYPE_NHS_GP, 'GP practice'),
-        (TYPE_EMERGENCY_SERVICE, 'Emergency service'),
-        (TYPE_SCHOOL_OR_COLLEGE, 'School or college'),
-        (TYPE_OTHER, 'Other'),
+        ('charity', 'Charity'),
+        ('community_interest', 'Community Interest Company'),
+        ('other', 'Other'),
     )
 
     ALLOWED_PROPERTIES = {

--- a/app/templates/views/add-service.html
+++ b/app/templates/views/add-service.html
@@ -22,6 +22,8 @@
         {{ form.organisation_type }}
       {% endif %}
 
+      {{ form.service_description }}
+
       {{ page_footer('Add service') }}
 
     {% endcall %}

--- a/app/templates/views/register.html
+++ b/app/templates/views/register.html
@@ -15,7 +15,6 @@ Create an account
       {{ form.name(param_extensions={"classes": "govuk-!-width-three-quarters"}) }}
       {{ form.email_address(
         param_extensions={
-          "hint": {"text": "Must be from a civil society organisation"},
           "classes": "govuk-!-width-three-quarters",
           "autocomplete": "email"
         },


### PR DESCRIPTION
This PR updates the existing "Create an account" workflow, making it
better suited to the needs of Catalyst Notify:

* Signups are no longer restricted to users with governmental email
addresses.
* The options shown under "Who runs this service?" are now appropriate
to the charity / not-for-profit sector.
* Introduction of a new question, "What type of work do you do?",
providing Catalyst admins with extra context when reviewing recent
signups.

<img width="552" alt="Screenshot 2021-03-12 at 17 25 03" src="https://user-images.githubusercontent.com/1914715/110976353-b3183180-8358-11eb-879a-16973d0c121b.png">
