### PR TITLE
✨ Add support for setting a service description

### DIFF
--- a/app/main/views/add_service.py
+++ b/app/main/views/add_service.py
@@ -9,12 +9,13 @@ from app.main.forms import CreateNhsServiceForm, CreateServiceForm
 from app.utils import user_is_logged_in
 
 
-def _create_service(service_name, organisation_type, email_from, form):
+def _create_service(service_name, service_description, organisation_type, email_from, form):
     free_sms_fragment_limit = current_app.config['DEFAULT_FREE_SMS_FRAGMENT_LIMITS'].get(organisation_type)
 
     try:
         service_id = service_api_client.create_service(
             service_name=service_name,
+            service_description=service_description,
             organisation_type=organisation_type,
             message_limit=current_app.config['DEFAULT_SERVICE_LIMIT'],
             restricted=True,
@@ -60,9 +61,11 @@ def add_service():
     if form.validate_on_submit():
         email_from = email_safe(form.name.data)
         service_name = form.name.data
+        service_description = form.service_description.data
 
         service_id, error = _create_service(
             service_name,
+            service_description,
             default_organisation_type or form.organisation_type.data,
             email_from,
             form,

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -13,6 +13,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
     def create_service(
         self,
         service_name,
+        service_description,
         organisation_type,
         message_limit,
         restricted,
@@ -24,6 +25,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
         """
         data = {
             "name": service_name,
+            "description": service_description,
             "organisation_type": organisation_type,
             "active": True,
             "message_limit": message_limit,


### PR DESCRIPTION
This commit adds back-end support for a `Service.description` attribute
that has recently been added to the front-end signup form. Submission of
this new field allows Catalyst admins to make a better informed decision
about whether an applicant charity should be granted access to the
Catalyst Notify application.