### PR TITLE
Update go live request process

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1560,39 +1560,16 @@ class Triage(StripWhitespaceForm):
 
 class EstimateUsageForm(StripWhitespaceForm):
 
-    volume_email = ForgivingIntegerField(
-        'How many emails do you expect to send in the next year?',
-        things='emails',
-        format_error_suffix='you expect to send',
-    )
     volume_sms = ForgivingIntegerField(
         'How many text messages do you expect to send in the next year?',
         things='text messages',
         format_error_suffix='you expect to send',
     )
-    volume_letter = ForgivingIntegerField(
-        'How many letters do you expect to send in the next year?',
-        things='letters',
-        format_error_suffix='you expect to send',
-    )
-    consent_to_research = GovukRadiosField(
-        'Can we contact you when we’re doing user research?',
-        choices=[
-            ('yes', 'Yes'),
-            ('no', 'No'),
-        ],
-        thing='yes or no',
-        param_extensions={
-            'hint': {'text': 'You do not have to take part and you can unsubscribe at any time'}
-        }
-    )
 
     at_least_one_volume_filled = True
 
     def validate(self, *args, **kwargs):
-
-        if self.volume_email.data == self.volume_sms.data == self.volume_letter.data == 0:
-            self.at_least_one_volume_filled = False
+        if self.volume_sms.data == 0:
             return False
 
         return super().validate(*args, **kwargs)

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -171,10 +171,8 @@ def estimate_usage(service_id):
 
     if form.validate_on_submit():
         current_service.update(
-            volume_email=form.volume_email.data,
             volume_sms=form.volume_sms.data,
-            volume_letter=form.volume_letter.data,
-            consent_to_research=(form.consent_to_research.data == 'yes'),
+            consent_to_research=False,
         )
         return redirect(url_for(
             'main.request_to_go_live',

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -198,7 +198,6 @@ def request_to_go_live(service_id):
 
 @main.route("/services/<uuid:service_id>/service-settings/request-to-go-live", methods=['POST'])
 @user_has_permissions('manage_service')
-@user_is_gov_user
 def submit_request_to_go_live(service_id):
 
     zendesk_client.create_ticket(

--- a/app/main/views/service_settings.py
+++ b/app/main/views/service_settings.py
@@ -199,49 +199,6 @@ def request_to_go_live(service_id):
 @main.route("/services/<uuid:service_id>/service-settings/request-to-go-live", methods=['POST'])
 @user_has_permissions('manage_service')
 def submit_request_to_go_live(service_id):
-
-    zendesk_client.create_ticket(
-        subject='Request to go live - {}'.format(current_service.name),
-        message=(
-            'Service: {service_name}\n'
-            '{service_dashboard}\n'
-            '\n---'
-            '\nOrganisation type: {organisation_type}'
-            '\nAgreement signed: {agreement}'
-            '\n'
-            '\nEmails in next year: {volume_email_formatted}'
-            '\nText messages in next year: {volume_sms_formatted}'
-            '\nLetters in next year: {volume_letter_formatted}'
-            '\n'
-            '\nConsent to research: {research_consent}'
-            '\nOther live services: {existing_live}'
-            '\n'
-            '\nService reply-to address: {email_reply_to}'
-            '\n'
-            '\n---'
-            '\nRequest sent by {email_address}'
-            '\n'
-        ).format(
-            service_name=current_service.name,
-            service_dashboard=url_for('main.service_dashboard', service_id=current_service.id, _external=True),
-            organisation_type=str(current_service.organisation_type).title(),
-            agreement=current_service.organisation.as_agreement_statement_for_go_live_request(
-                current_user.email_domain
-            ),
-            volume_email_formatted=format_thousands(current_service.volume_email),
-            volume_sms_formatted=format_thousands(current_service.volume_sms),
-            volume_letter_formatted=format_thousands(current_service.volume_letter),
-            research_consent='Yes' if current_service.consent_to_research else 'No',
-            existing_live='Yes' if current_user.live_services else 'No',
-            email_address=current_user.email_address,
-            email_reply_to=current_service.default_email_reply_to_address or 'not set',
-        ),
-        ticket_type=zendesk_client.TYPE_QUESTION,
-        user_email=current_user.email_address,
-        user_name=current_user.name,
-        tags=current_service.request_to_go_live_tags,
-    )
-
     current_service.update(go_live_user=current_user.id)
 
     flash('Thanks for your request to go live. We’ll get back to you within one working day.', 'default')

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -444,7 +444,6 @@ class Service(JSONModel):
             bool(self.volumes),
             self.has_team_members,
             self.has_templates,
-            not self.needs_to_add_email_reply_to_address,
             not self.needs_to_change_sms_sender,
         ))
 

--- a/app/templates/views/service-settings/estimate-usage.html
+++ b/app/templates/views/service-settings/estimate-usage.html
@@ -25,15 +25,7 @@
       {% endif %}
       {% call form_wrapper() %}
         <div class="form-group">
-          {{ form.volume_email(param_extensions={
-            "classes": "govuk-!-width-one-half",
-            "hint": {"text": "For example, 50,000"},
-          }) }}
           {{ form.volume_sms(param_extensions={
-            "classes": "govuk-!-width-one-half",
-            "hint": {"text": "For example, 50,000"},
-          }) }}
-          {{ form.volume_letter(param_extensions={
             "classes": "govuk-!-width-one-half",
             "hint": {"text": "For example, 50,000"},
           }) }}

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -49,11 +49,7 @@
           ) }}
         {% endif %}
       {% endcall %}
-      {% if not current_user.is_gov_user %}
-        <p class="govuk-body">
-          Only team members with a government email address can request to go live.
-        </p>
-      {% elif (not current_service.go_live_checklist_completed) or (current_service.able_to_accept_agreement and not current_service.organisation.agreement_signed) %}
+      {% if (not current_service.go_live_checklist_completed) or (current_service.able_to_accept_agreement and not current_service.organisation.agreement_signed) %}
         <p class="govuk-body">
           You must complete these steps before you can request to go live.
         </p>

--- a/app/templates/views/service-settings/request-to-go-live.html
+++ b/app/templates/views/service-settings/request-to-go-live.html
@@ -31,13 +31,6 @@
           'Add templates with examples of the content you plan to send',
           url_for('main.choose_template', service_id=current_service.id),
         ) }}
-        {% if current_service.intending_to_send_email %}
-          {{ task_list_item(
-            current_service.has_email_reply_to_address,
-            'Add a reply-to email address',
-            url_for('main.service_email_reply_to', service_id=current_service.id),
-          ) }}
-        {% endif %}
         {% if (
           current_service.intending_to_send_sms
           and current_service.shouldnt_use_govuk_as_sms_sender


### PR DESCRIPTION
 When a charity wishes to promote its service from a "trial" to "live"
 account, they must answer some questions about the volume of messages
 they intend to send, their agreement to be contacted for questioning
 and also to set an email reply-to address. This PR adapts this
 questionnaire to match the needs of the Catalyst alpha release.