### PR TITLE
Tiny copy change on pricing section on homepage

### DIFF
--- a/app/templates/views/signedout.html
+++ b/app/templates/views/signedout.html
@@ -115,7 +115,7 @@
       <div class="govuk-grid-row bottom-gutter">
         <div class="govuk-grid-column-one-half">
           <h3 class="govuk-visually-hidden">Text messages</h3>
-          <div class="product-page-big-number">Free up to 1000 messages a month for charities accepted on the Alpha test.</div>
+          <div class="product-page-big-number">100 free messages for charities accepted on the Alpha test</div>
         </div>
         <div class="govuk-grid-column-one-half">
           <p class="align-with-big-number-hint">


### PR DESCRIPTION
Can we please update the pricing section on the homepage to rather read:
"100 free messages for charities accepted on the Alpha test" 

Card: https://app.asana.com/0/1199707043388412/1200246041223029