### PR TITLE
More copy changes from client

### DIFF
--- a/app/templates/views/accessibility_statement.html
+++ b/app/templates/views/accessibility_statement.html
@@ -50,7 +50,7 @@
   <h2 class="heading-medium">Feedback and contact information</h2>
 
   <p class="govuk-body">
-    If you need any part of this service in a different format like large print, audio recording or braille, <a class="govuk-link" href="https://www.notifications.service.gov.uk/support">contact the Catalyst Notify team</a>.
+    If you need any part of this service in a different format like large print, audio recording or braille, <a class="govuk-link" href="/support">contact the Catalyst Notify team</a>.
   </p>
 
   <p class="govuk-body">
@@ -60,7 +60,7 @@
   <h2 class="heading-medium">Reporting accessibility problems with this website</h2>
 
   <p class="govuk-body">
-    We’re always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, <a class="govuk-link" href="https://www.notifications.service.gov.uk/support">contact the GOV.UK Notify team</a>.
+    We’re always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we’re not meeting accessibility requirements, <a class="govuk-link" href="/support">contact the Catalyst Notify team</a>.
   </p>
 
   <h2 class="heading-medium">Enforcement procedure</h2>
@@ -77,82 +77,5 @@
 
   <p class="govuk-body">
     Catalyst is committed to making its website accessible
-  </p>
-
-  <h2 class="heading-medium">Non-accessible content</h2>
-
-  <p class="govuk-body">
-    The content listed below is non-accessible for the following reasons.
-  </p>
-
-  <h3 class="heading-small">Non compliance with the accessibility regulations</h3>
-
-  <p class="govuk-body">
-    Screen reader users may find the process of moving templates and folders confusing. This fails <a class="govuk-link" href="https://www.w3.org/TR/WCAG21/#name-role-value">WCAG 2.1 success criteria 4.1.2 (Name, role, value)</a>.</p>
-
-  <p class="govuk-body">We made some changes that will be tested by the Digital Accessibility Centre (DAC) at the end of January. If possible, we plan to fix this by March 2021.
-  </p>
-
-  <h3 class="heading-small">
-    PDFs and other documents
-  </h3>
-
-  <p class="govuk-body">
-    One page links to a PDF document that is not fully accessible. This is not a fail under any WCAG 2.1 success criterion.</p>
-
-  <p class="govuk-body">
-    We provide a written description of the information in the PDF on an HTML page as an accessible alternative.
-  </p>
-
-  <h3 class="heading-small">
-    Emails
-  </h3>
-
-  <p class="govuk-body">
-    The JAWS and NVDA screen readers announce extra spaces in emails when viewed in Microsoft Outlook.
-  </p>
-
-  <p class="govuk-body">
-    We’ll continue to investigate the cause of this issue and, if possible, fix it by March 2021.
-  </p>
-
-  <h3 class="heading-small">
-    Status page
-  </h3>
-
-  <p class="govuk-body">
-    The following content on the <a class="govuk-link" href="https://status.notifications.service.gov.uk/">Notify status page</a> is not compliant with the Web Content Accessibility Guidelines version 2.1 AA standard:
-  </p>
-
-  <ul class="govuk-list govuk-list--bullet">
-    <li>an incorrect heading hierarchy which fails <a href="https://www.w3.org/TR/WCAG21/#info-and-relationships">WCAG 2.1 success criterion 1.3.1 (Info and Relationships)</a></li>
-    <li>missing level 1 headings (users may not be able to accurately determine the structure of content on the page)</li>
-    <li>our status incident page is missing the main heading and the status home page has an incorrect heading hierarchy – this fails <a href="https://www.w3.org/TR/WCAG21/#info-and-relationships">WCAG 2.1 success criterion 1.3.1 (Info and Relationships)</a></li>
-    <li>our status page ‘subscribe to updates’ link does not contain programmatically discernible link text – this fails <a href="https://www.w3.org/TR/WCAG21/#info-and-relationships">WCAG 2.1 success criterion 1.3.1 (Info and Relationships)</a></li>
-    <li>our status page subscribe to updates form fields do not contain an explicit label – this fails <a href="https://www.w3.org/TR/WCAG21/#info-and-relationships">WCAG 2.1 success criterion 1.3.1 (Info and Relationships)</a></li>
-    <li>our status page subscribe to updates forms do not indicate to users that they are expandable or collapsible – this fails <a href="https://www.w3.org/TR/WCAG21/#name-role-value">WCAG 2.1 success criterion 4.1.2 (Name, Role, Value)</a></li>
-    <li>our status page subscribe to updates forms contain some text that does not meet the minimum colour contrast requirements – this fails <a href="https://www.w3.org/TR/WCAG21/#contrast-minimum">WCAG 2.1A success criterion 1.4.3 (Contrast, Minimum)</a></li>
-    <li>our status page subscribe to updates form close link (x) is not descriptive enough for some users to determine its function or purpose – this fails <a href="https://www.w3.org/TR/WCAG21/#link-purpose-in-context">WCAG 2.1 success criterion 2.4.4 (Link Purpose, In Context)</a></li>
-    <li>our status page subscribe to updates forms, when submitted with incorrect data, do not inform screen reader users of the error message when it becomes available – this fails <a href="https://www.w3.org/TR/WCAG21/#status-messages">WCAG 2.1 success criterion 4.1.3 (Status Messages)</a></li>
-  </ul>
-
-  <p class="govuk-body">
-    We plan to have the status page issues addressed by the current supplier or move to an alternative supplier in 2021.
-  </p>
-
-  <h2 class="heading-medium">
-    How we tested this service
-  </h2>
-
-  <p class="govuk-body">
-    The parts of the website used to send text messages, emails and letters were last tested on 15 July 2020. The emails we send out, the web pages users see when they are sent a file by Notify and a sample letter PDF were last tested on 11th March 2019. Both tests were carried out by DAC.
-  </p>
-
-  <p class="govuk-body">
-    We decided which pages to test based on the most common tasks that GOV.UK Notify users need to complete. We also tested a sample of pages with common user interface components.
-  </p>
-
-  <p class="govuk-body">
-    This statement was prepared on 23 September 2020. It was last reviewed on 14 January 2021.
   </p>
 {% endblock %}

--- a/app/templates/views/privacy.html
+++ b/app/templates/views/privacy.html
@@ -119,36 +119,8 @@
     </ul>
 
     <p class="govuk-body">
-    Privacy Team<br>
-    <a class="govuk-link govuk-link--no-visited-state" href="">TODO</a>
+      To contact the Privacy Team at CAST, please email <a href="mailto:privacy@wearecast.org.uk" class="govuk-link govuk-link--no-visited-state">privacy@wearecast.org.uk</a>.
     </p>
-
-    <p class="govuk-body">
-    You can also contact the Cabinet Office Data Protection Officer.
-    </p>
-
-    <p class="govuk-body">
-    Data Protection Officer<br>
-    <a class="govuk-link govuk-link--no-visited-state" href="mailto:DPO@cabinetoffice.gov.uk">DPO@cabinetoffice.gov.uk</a><br>
-    Data Protection Officer<br>
-    Cabinet Office<br>
-    70 Whitehall<br>
-    London SW1A 2AS
-    </p>
-
-    <p class="govuk-body">If you have a complaint, you can also contact the <a class="govuk-link govuk-link--no-visited-state" href="https://ico.org.uk/">Information Commissioner's Office</a> (ICO). The ICO is an independent regulator set up to uphold information rights.</p>
-
-    <p class="govuk-body">
-    Information Commissioner’s Office<br>
-    <a class="govuk-link govuk-link--no-visited-state" href="mailto:casework@ico.org.uk">casework@ico.org.uk</a><br>
-    0303 123 1113</br>
-    Wycliffe House<br>
-    Water Lane<br>
-    Wilmslow<br>
-    Cheshire SK9 5AF
-    </p>
-
-
   </div>
 </div>
 

--- a/app/templates/views/security.html
+++ b/app/templates/views/security.html
@@ -45,7 +45,7 @@
     <li>your email address and password</li>
     <li>a text message code that Notify sends to your phone</li>
   </ul>
-  <p class="govuk-body">If signing in with a text message is a problem for your team, <a class="govuk-link govuk-link--no-visited-state" href="https://www.notifications.service.gov.uk/">contact us</a> to find out about using an email link instead.</p>
+  <p class="govuk-body">If signing in with a text message is a problem for your team, <a class="govuk-link govuk-link--no-visited-state" href="/support">contact us</a> to find out about using an email link instead.</p>
 
   <h2 class="heading-medium">Information risk management</h2>
   <p class="govuk-body">Our approach to information risk management follows NCSC guidance. It assesses:</p>
@@ -65,13 +65,4 @@
     <li>regular updates to the Privacy Impact Assessment</li>
     <li>security impact assessments</li>
   </ul>
-
-  <h2 class="heading-medium">Cabinet Office approval</h2>
-  <p class="govuk-body">Notify has been assessed and approved by the Cabinet Office Senior Information Risk Officer (SIRO). The SIRO checks this approval once a year.</p>
-  <p class="govuk-body">Notify also has approval from the Office of the Government’s SIRO to host data within the EEA.</p>
-
-  <h2 class="heading-medium">Classifications and security vetting</h2>
-  <p class="govuk-body">You can use Notify to send messages classified as ‘OFFICIAL’ or ‘OFFICIAL-SENSITIVE’ under the <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/publications/government-security-classifications">Government Security Classifications</a> policy.</p>
-  <p class="govuk-body">The Notify team has Security Check (SC) level clearance from <a class="govuk-link govuk-link--no-visited-state" href="https://www.gov.uk/government/organisations/united-kingdom-security-vetting">United Kingdom Security Vetting</a> (UKSV).</p>
-
 {% endblock %}


### PR DESCRIPTION
Client requested some changes:

- Accessibility statement - link needs changing to: https://notifications.thecatalyst.org.uk/support  "If you need any part of this service in a different format like large print, audio recording or braille, contact the Catalyst Notify team."
- Accessibility statement- Reporting accessibility problems with this website section. Update contact the GOC.UK Notify team to: contact the Catalyst Notify team and link to link to https://notifications.thecatalyst.org.uk/support
- Accessibility statement - Remove everything from "Non-accessible content" onwards 
- Security page - "Two-factor authentication" section change link to https://notifications.thecatalyst.org.uk/support
- Security page - Remove everything from the "Cabinet Office approval" section onwards
- Privacy Policy - Update TODO copy beneath Privacy team in the questions and complaints section to read: "To contact the privacy team at CAST, please email privacy@wearecast.org.uk"  and link to email address, please


Card: https://app.asana.com/0/1199707043388412/1200252808497185