### PR TITLE
Updating privacy policy copy

### DIFF
--- a/app/templates/views/privacy.html
+++ b/app/templates/views/privacy.html
@@ -111,16 +111,11 @@
 
     <h2 class="heading-medium">Questions and complaints</h2>
 
-    <p class="govuk-body">Contact the Privacy Team if you either:</p>
-
-    <ul class="list list-bullet">
-      <li>have any questions about anything in this document</li>
-      <li>think that your personal data has been misused or mishandled</li>
-    </ul>
-
     <p class="govuk-body">
-      To contact the Privacy Team at CAST, please email <a href="mailto:privacy@wearecast.org.uk" class="govuk-link govuk-link--no-visited-state">privacy@wearecast.org.uk</a>.
-    </p>
+      If you have concerns about the way CAST is handling your User Personal Information, please let us know immediately. You may contact us by emailing us directly at <a class="govuk-link govuk-link--no-visited-state" href="mailto:privacy@wearecast.org.uk">privacy@wearecast.org.uk</a> with the subject line “Privacy Concern”. We will respond within 30 days at the latest.
+      <br>
+      You may also contact our <strong>Data Protection Officer</strong> directly. Our <strong>Data Protection Officer</strong> is Gilly Clyde-Smith (<a class="govuk-link govuk-link--no-visited-state" href="mailto:gilly@wearecast.org.uk">gilly@wearecast.org.uk</a>).
+    </p>p>
   </div>
 </div>
 

--- a/app/templates/views/privacy.html
+++ b/app/templates/views/privacy.html
@@ -115,7 +115,7 @@
       If you have concerns about the way CAST is handling your User Personal Information, please let us know immediately. You may contact us by emailing us directly at <a class="govuk-link govuk-link--no-visited-state" href="mailto:privacy@wearecast.org.uk">privacy@wearecast.org.uk</a> with the subject line “Privacy Concern”. We will respond within 30 days at the latest.
       <br>
       You may also contact our <strong>Data Protection Officer</strong> directly. Our <strong>Data Protection Officer</strong> is Gilly Clyde-Smith (<a class="govuk-link govuk-link--no-visited-state" href="mailto:gilly@wearecast.org.uk">gilly@wearecast.org.uk</a>).
-    </p>p>
+    </p>
   </div>
 </div>
 


### PR DESCRIPTION
If you have concerns about the way CAST is handling your User Personal Information, please let us know immediately. You may contact us by emailing us directly at privacy@wearecast.org.uk with the subject line “Privacy Concern”. We will respond within 30 days at the latest.
You may also contact our Data Protection Officer directly. Our Data Protection Officer is Gilly Clyde-Smith (gilly@wearecast.org.uk).

So it will read:
Questions and complaints
If you have concerns about the way CAST is handling your User Personal Information, please let us know immediately. You may contact us by emailing us directly at privacy@wearecast.org.uk with the subject line “Privacy Concern”. We will respond within 30 days at the latest.
You may also contact our Data Protection Officer directly. Our Data Protection Officer is Gilly Clyde-Smith (gilly@wearecast.org.uk).