### PR TITLE
Changing default SMS allowances for new registrations

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -33,16 +33,16 @@ class Config(object):
     AWS_REGION = get_env_var('AWS_REGION', 'eu-west-1')
     DEFAULT_SERVICE_LIMIT = 50
     DEFAULT_FREE_SMS_FRAGMENT_LIMITS = {
-        'central': 250000,
-        'local': 25000,
-        'nhs_central': 250000,
-        'nhs_local': 25000,
-        'nhs_gp': 25000,
-        'emergency_service': 25000,
-        'school_or_college': 25000,
-        'other': 25000,
-        'charity': 25000,
-        'community_interest': 25000
+        'central': 1000,
+        'local': 1000,
+        'nhs_central': 1000,
+        'nhs_local': 1000,
+        'nhs_gp': 1000,
+        'emergency_service': 1000,
+        'school_or_college': 1000,
+        'other': 1000,
+        'charity': 1000,
+        'community_interest': 1000
     }
     EMAIL_EXPIRY_SECONDS = 3600  # 1 hour
     INVITATION_EXPIRY_SECONDS = 3600 * 24 * 2  # 2 days - also set on api

--- a/app/notify_client/service_api_client.py
+++ b/app/notify_client/service_api_client.py
@@ -127,7 +127,7 @@ class ServiceAPIClient(NotifyAdminAPIClient):
     def update_status(self, service_id, live):
         return self.update_service(
             service_id,
-            message_limit=250000 if live else 50,
+            message_limit=1000 if live else 50,
             restricted=(not live),
             go_live_at=str(datetime.utcnow()) if live else None
         )

--- a/tests/app/main/views/organisations/test_organisation.py
+++ b/tests/app/main/views/organisations/test_organisation.py
@@ -401,10 +401,10 @@ def test_organisation_services_shows_live_services_and_usage(
         'app.organisations_client.get_services_and_usage',
         return_value={"services": [
             {'service_id': SERVICE_ONE_ID, 'service_name': '1', 'chargeable_billable_sms': 250122, 'emails_sent': 13000,
-             'free_sms_limit': 250000, 'letter_cost': 30.50, 'sms_billable_units': 122, 'sms_cost': 0,
+             'free_sms_limit': 1000, 'letter_cost': 30.50, 'sms_billable_units': 122, 'sms_cost': 0,
              'sms_remainder': None},
             {'service_id': SERVICE_TWO_ID, 'service_name': '5', 'chargeable_billable_sms': 0, 'emails_sent': 20000,
-             'free_sms_limit': 250000, 'letter_cost': 0, 'sms_billable_units': 2500, 'sms_cost': 42.0,
+             'free_sms_limit': 1000, 'letter_cost': 0, 'sms_billable_units': 2500, 'sms_cost': 42.0,
              'sms_remainder': None}
         ]}
     )
@@ -450,7 +450,7 @@ def test_organisation_services_shows_live_services_and_usage_with_count_of_1(
         'app.organisations_client.get_services_and_usage',
         return_value={"services": [
             {'service_id': SERVICE_ONE_ID, 'service_name': '1', 'chargeable_billable_sms': 1, 'emails_sent': 1,
-             'free_sms_limit': 250000, 'letter_cost': 0, 'sms_billable_units': 1, 'sms_cost': 0,
+             'free_sms_limit': 1000, 'letter_cost': 0, 'sms_billable_units': 1, 'sms_cost': 0,
              'sms_remainder': None},
         ]}
     )
@@ -521,7 +521,7 @@ def test_organisation_services_shows_search_bar(
                 'service_name': 'Service 1',
                 'chargeable_billable_sms': 250122,
                 'emails_sent': 13000,
-                'free_sms_limit': 250000,
+                'free_sms_limit': 1000,
                 'letter_cost': 30.50,
                 'sms_billable_units': 122,
                 'sms_cost': 1.93,
@@ -568,7 +568,7 @@ def test_organisation_services_hides_search_bar_for_7_or_fewer_services(
                 'service_name': 'Service 1',
                 'chargeable_billable_sms': 250122,
                 'emails_sent': 13000,
-                'free_sms_limit': 250000,
+                'free_sms_limit': 1000,
                 'letter_cost': 30.50,
                 'sms_billable_units': 122,
                 'sms_cost': 1.93,

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -214,9 +214,9 @@ def test_get_should_only_show_nhs_org_types_radios_if_user_has_nhs_email(
 
 
 @pytest.mark.parametrize('organisation_type, free_allowance', [
-    ('charity', 25 * 1000),
-    ('community_interest', 25 * 1000),
-    ('other', 25 * 1000),
+    ('charity', 1000),
+    ('community_interest', 1000),
+    ('other', 1000),
 ])
 def test_should_add_service_and_redirect_to_dashboard_when_existing_service(
     app_,

--- a/tests/app/main/views/test_add_service.py
+++ b/tests/app/main/views/test_add_service.py
@@ -88,12 +88,12 @@ def test_show_different_page_if_user_org_type_is_local(
     'test@example.nhs.uk',
 ))
 @pytest.mark.parametrize('inherited, posted, persisted, sms_limit', (
-    (None, 'charity', 'charity', 25000),
-    ('charity', None, 'charity', 25000),
-    (None, 'community_interest', 'community_interest', 25000),
-    ('community_interest', None, 'community_interest', 25000),
-    (None, 'other', 'other', 25000),
-    ('other', None, 'other', 25000)
+    (None, 'charity', 'charity', 1000),
+    ('charity', None, 'charity', 1000),
+    (None, 'community_interest', 'community_interest', 1000),
+    ('community_interest', None, 'community_interest', 1000),
+    (None, 'other', 'other', 1000),
+    ('other', None, 'other', 1000)
 ))
 def test_should_add_service_and_redirect_to_tour_when_no_services(
     mocker,

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -1115,8 +1115,8 @@ def test_usage_page_displays_sms_messages_split_by_month(
     mock_get_free_sms_fragment_limit
 ):
     billable_units_resp = [
-        {'month': 'April', 'notification_type': 'sms', 'rate': 1.65, 'billing_units': 100000},
-        {'month': 'May', 'notification_type': 'sms', 'rate': 2.15, 'billing_units': 200000},
+        {'month': 'April', 'notification_type': 'sms', 'rate': 1.65, 'billing_units': 500},
+        {'month': 'May', 'notification_type': 'sms', 'rate': 2.15, 'billing_units': 1000},
         {'month': 'June', 'notification_type': 'sms', 'rate': 0.75, 'billing_units': 100000},
     ]
     mocker.patch('app.billing_api_client.get_billable_units', return_value=billable_units_resp)
@@ -1131,8 +1131,8 @@ def test_usage_page_displays_sms_messages_split_by_month(
     june_row = normalize_spaces(page.find('table').find_all('tr')[3].text)
 
     assert '£0.00 1,000 free text messages' in april_row
-    assert '£825.00 1,000 free text messages 50,000 text messages at 1.65p' in may_row
-    assert '£1,650.00 1,000 text messages at 1.65p' in june_row
+    assert '£1,075.00 1,000 free text messages 50,000 text messages at 1.65p' in may_row
+    assert '£75,000.00 1,000 text messages at 1.65p' in june_row
 
 
 def test_usage_page_with_year_argument(

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -1538,15 +1538,15 @@ def test_get_free_paid_breakdown_for_billable_units(now, expected_number_of_mont
             2016, sms_allowance, [
                 {
                     'month': 'April', 'international': False, 'rate_multiplier': 1,
-                    'notification_type': 'sms', 'rate': 1.65, 'billing_units': 1000
+                    'notification_type': 'sms', 'rate': 1.65, 'billing_units': 500
                 },
                 {
                     'month': 'May', 'international': False, 'rate_multiplier': 1,
-                    'notification_type': 'sms', 'rate': 1.65, 'billing_units': 1000
+                    'notification_type': 'sms', 'rate': 1.65, 'billing_units': 500
                 },
                 {
                     'month': 'June', 'international': False, 'rate_multiplier': 1,
-                    'notification_type': 'sms', 'rate': 1.65, 'billing_units': 1000
+                    'notification_type': 'sms', 'rate': 1.65, 'billing_units': 500
                 },
                 {
                     'month': 'February', 'international': False, 'rate_multiplier': 1,
@@ -1555,8 +1555,8 @@ def test_get_free_paid_breakdown_for_billable_units(now, expected_number_of_mont
             ]
         )
         assert list(billing_units) == [
-            {'free': 1000, 'name': 'April', 'paid': 0, 'letter_total': 0, 'letters': [], 'letter_cumulative': 0},
-            {'free': 1000, 'name': 'May', 'paid': 0, 'letter_total': 0, 'letters': [], 'letter_cumulative': 0},
+            {'free': 500, 'name': 'April', 'paid': 0, 'letter_total': 0, 'letters': [], 'letter_cumulative': 0},
+            {'free': 500, 'name': 'May', 'paid': 0, 'letter_total': 0, 'letters': [], 'letter_cumulative': 0},
             {'free': 500, 'name': 'June', 'paid': 500, 'letter_total': 0, 'letters': [], 'letter_cumulative': 0},
             {'free': 0, 'name': 'July', 'paid': 0, 'letter_total': 0, 'letters': [], 'letter_cumulative': 0},
             {'free': 0, 'name': 'August', 'paid': 0, 'letter_total': 0, 'letters': [], 'letter_cumulative': 0},

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -1538,15 +1538,15 @@ def test_get_free_paid_breakdown_for_billable_units(now, expected_number_of_mont
             2016, sms_allowance, [
                 {
                     'month': 'April', 'international': False, 'rate_multiplier': 1,
-                    'notification_type': 'sms', 'rate': 1.65, 'billing_units': 100000
+                    'notification_type': 'sms', 'rate': 1.65, 'billing_units': 1000
                 },
                 {
                     'month': 'May', 'international': False, 'rate_multiplier': 1,
-                    'notification_type': 'sms', 'rate': 1.65, 'billing_units': 100000
+                    'notification_type': 'sms', 'rate': 1.65, 'billing_units': 1000
                 },
                 {
                     'month': 'June', 'international': False, 'rate_multiplier': 1,
-                    'notification_type': 'sms', 'rate': 1.65, 'billing_units': 100000
+                    'notification_type': 'sms', 'rate': 1.65, 'billing_units': 1000
                 },
                 {
                     'month': 'February', 'international': False, 'rate_multiplier': 1,
@@ -1733,6 +1733,6 @@ def test_should_show_usage_on_dashboard(
     ) == (
         'Unlimited '
         'free email allowance '
-        '£4,144.64 '
+        '£36.14 '
         'spent on text messages'
     )

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -1056,7 +1056,7 @@ def test_usage_page_with_letters(
 
     table = page.find('table').text.strip()
 
-    assert '249,860 free text messages' in table
+    assert '860 free text messages' in table
     assert '40 free text messages' in table
     assert '960 text messages at 1.65p' in table
     assert 'April' in table
@@ -1130,9 +1130,9 @@ def test_usage_page_displays_sms_messages_split_by_month(
     may_row = normalize_spaces(page.find('table').find_all('tr')[2].text)
     june_row = normalize_spaces(page.find('table').find_all('tr')[3].text)
 
-    assert '£0.00 100,000 free text messages' in april_row
-    assert '£825.00 150,000 free text messages 50,000 text messages at 1.65p' in may_row
-    assert '£1,650.00 100,000 text messages at 1.65p' in june_row
+    assert '£0.00 1,000 free text messages' in april_row
+    assert '£825.00 1,000 free text messages 50,000 text messages at 1.65p' in may_row
+    assert '£1,650.00 1,000 text messages at 1.65p' in june_row
 
 
 def test_usage_page_with_year_argument(
@@ -1555,9 +1555,9 @@ def test_get_free_paid_breakdown_for_billable_units(now, expected_number_of_mont
             ]
         )
         assert list(billing_units) == [
-            {'free': 100000, 'name': 'April', 'paid': 0, 'letter_total': 0, 'letters': [], 'letter_cumulative': 0},
-            {'free': 100000, 'name': 'May', 'paid': 0, 'letter_total': 0, 'letters': [], 'letter_cumulative': 0},
-            {'free': 50000, 'name': 'June', 'paid': 50000, 'letter_total': 0, 'letters': [], 'letter_cumulative': 0},
+            {'free': 1000, 'name': 'April', 'paid': 0, 'letter_total': 0, 'letters': [], 'letter_cumulative': 0},
+            {'free': 1000, 'name': 'May', 'paid': 0, 'letter_total': 0, 'letters': [], 'letter_cumulative': 0},
+            {'free': 500, 'name': 'June', 'paid': 500, 'letter_total': 0, 'letters': [], 'letter_cumulative': 0},
             {'free': 0, 'name': 'July', 'paid': 0, 'letter_total': 0, 'letters': [], 'letter_cumulative': 0},
             {'free': 0, 'name': 'August', 'paid': 0, 'letter_total': 0, 'letters': [], 'letter_cumulative': 0},
             {'free': 0, 'name': 'September', 'paid': 0, 'letter_total': 0, 'letters': [], 'letter_cumulative': 0},
@@ -1733,6 +1733,6 @@ def test_should_show_usage_on_dashboard(
     ) == (
         'Unlimited '
         'free email allowance '
-        '£36.14 '
+        '£4,144.64 '
         'spent on text messages'
     )

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -1532,7 +1532,7 @@ def test_aggregate_status_types(dict_in, expected_failed, expected_requested):
     ]
 )
 def test_get_free_paid_breakdown_for_billable_units(now, expected_number_of_months):
-    sms_allowance = 250000
+    sms_allowance = 1000
     with now:
         billing_units = get_free_paid_breakdown_for_billable_units(
             2016, sms_allowance, [

--- a/tests/app/main/views/test_dashboard.py
+++ b/tests/app/main/views/test_dashboard.py
@@ -1014,7 +1014,7 @@ def test_usage_page(
 
     table = page.find('table').text.strip()
 
-    assert '249,860 free text messages' in table
+    assert '860 free text messages' in table
     assert '40 free text messages' in table
     assert '960 text messages at 1.65p' in table
     assert 'April' in table

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -99,7 +99,7 @@ def mock_get_service_settings_page_common(
         'Organisation Test organisation Charity Change organisation for service',
         'Rate limit 3,000 per minute Change rate limit',
         'Message limit 1,000 per day Change daily message limit',
-        'Free text message allowance 250,000 per year Change free text message allowance',
+        'Free text message allowance 1,000 per year Change free text message allowance',
         'Email branding GOV.UK Change email branding (admin view)',
         'Letter branding Not set Change letter branding (admin view)',
         'Custom data retention Email – 7 days Change data retention',
@@ -3685,7 +3685,7 @@ def test_unknown_channel_404s(
     ),
     (
         'sms',
-        'You have a free allowance of 250,000 text messages each financial year.',
+        'You have a free allowance of 1,000 text messages each financial year.',
         'Send text messages',
         [],
         'False',

--- a/tests/app/main/views/test_service_settings.py
+++ b/tests/app/main/views/test_service_settings.py
@@ -577,7 +577,7 @@ def test_switch_service_to_live(
     )
     mock_update_service.assert_called_with(
         SERVICE_ONE_ID,
-        message_limit=250000,
+        message_limit=1000,
         restricted=False,
         go_live_at="2017-04-01 11:09:00.061258"
     )
@@ -3528,7 +3528,7 @@ def test_should_show_page_to_set_sms_allowance(
 @freeze_time("2017-04-01 11:09:00.061258")
 @pytest.mark.parametrize('given_allowance, expected_api_argument', [
     ('1', 1),
-    ('250000', 250000),
+    ('1000', 1000),
     pytest.param('foo', 'foo', marks=pytest.mark.xfail),
 ])
 def test_should_set_sms_allowance(
@@ -3599,7 +3599,7 @@ def test_should_show_page_to_set_rate_limit(
 ))
 @pytest.mark.parametrize('new_limit, expected_api_argument', [
     ('1', 1),
-    ('250000', 250000),
+    ('1000', 1000),
     pytest.param('foo', 'foo', marks=pytest.mark.xfail),
 ])
 def test_should_set_message_limit(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3241,14 +3241,14 @@ def mock_update_service_data_retention(mocker):
 
 @pytest.fixture(scope='function')
 def mock_get_free_sms_fragment_limit(mocker):
-    sample_limit = 250000
+    sample_limit = 1000
     return mocker.patch('app.billing_api_client.get_free_sms_fragment_limit_for_year',
                         return_value=sample_limit)
 
 
 @pytest.fixture(scope='function')
 def mock_create_or_update_free_sms_fragment_limit(mocker):
-    sample_limit = 250000
+    sample_limit = 1000
     return mocker.patch('app.billing_api_client.create_or_update_free_sms_fragment_limit',
                         return_value=sample_limit)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2619,7 +2619,7 @@ def mock_get_usage(mocker, service_one, fake_uuid):
     def _get_usage(service_id, year=None):
         return [
             {"notification_type": "email", "billing_units": 1000, "rate": 0.00, "letter_total": 0},
-            {"notification_type": "sms", "billing_units": 251500, "rate": 0.0165, "letter_total": 0},
+            {"notification_type": "sms", "billing_units": 2500, "rate": 0.0165, "letter_total": 0},
             {"notification_type": "sms", "billing_units": 300, "rate": 0.0165, "letter_total": 0},
             {"notification_type": "sms", "billing_units": 300, "rate": 0.0165, "letter_total": 0},
             {"notification_type": "sms", "billing_units": 90, "rate": 0.0165, "letter_total": 0}


### PR DESCRIPTION
Changes app config from 250k free messages to 1k messages allowance.

Card: https://app.asana.com/0/1199707043388412/1200295479855404/f